### PR TITLE
Small changes to make the example repos idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ npm start
 npm test
 ```
 
-## Pro Tips
-
-- If you encounter the error `TypeError: Cannot call method 'baseUrl' of undefined`, be sure that the environment set in your `.env` file is capitalized. For example, when using the sandbox environment, it should be set to `Sandbox` and not `sandbox`.
-
 ## Disclaimer
 
 This code is provided as is and is only intended to be used for illustration purposes. This code is not production-ready and is not meant to be used in a production environment. This repository is to be used as a tool to help merchants learn how to integrate with Braintree. Any use of this repository or any of its code in a production environment is highly discouraged.

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -1,8 +1,10 @@
 var braintree = require('braintree');
 require('dotenv').load();
 
+var environment = process.env.BT_ENVIRONMENT.charAt(0).toUpperCase() + process.env.BT_ENVIRONMENT.slice(1);
+
 var gateway = braintree.connect({
-  environment: braintree.Environment[process.env.BT_ENVIRONMENT],
+  environment: braintree.Environment[environment],
   merchantId: process.env.BT_MERCHANT_ID,
   publicKey: process.env.BT_PUBLIC_KEY,
   privateKey: process.env.BT_PRIVATE_KEY,

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,9 +3,9 @@ var router = express.Router();
 var gateway = require('../lib/gateway');
 
 function formatErrors (errors) {
-  formattedErrors = '';
+  var formattedErrors = '';
   for (var i in errors) {
-    formattedErrors += errors[i].code + ' - ' + errors[i].message + '\n';
+    formattedErrors += 'Error: ' + errors[i].code + ': ' + errors[i].message + '\n';
   }
   return formattedErrors;
 }

--- a/test/checkout_test.js
+++ b/test/checkout_test.js
@@ -106,7 +106,7 @@ describe('Checkouts create', function(){
             var req = api.get('/checkouts/new')
             agent.attachCookies(req);
             req.end(function (err, res){
-              expect(res.text).to.contain('Amount is an invalid format');
+              expect(res.text).to.contain('Error: 81503: Amount is an invalid format.');
               done();
             });
           });

--- a/views/checkouts/new.jade
+++ b/views/checkouts/new.jade
@@ -6,7 +6,7 @@ block content
 
   h1 Checkout
   form(id="checkout", action="/checkouts", method="post")
-    label(for="amount") amount
+    label(for="amount") Amount
     input(type="text", name="amount", id="amount", value="10.00")
     div(id="payment-form")
     input(type="submit", value="Pay Now")

--- a/views/checkouts/show.jade
+++ b/views/checkouts/show.jade
@@ -4,7 +4,7 @@ block content
   for msg in messages
     div= msg.msg
 
-  h1 Transaction
+  h1 Transaction #{transaction.id}
     h2 Details
     table
       tr


### PR DESCRIPTION
Small changes to make the example repo idiomatic with the [braintree rails example repo](https://github.com/braintree/braintree_rails_example). 
