### PR TITLE
Add port configuration to checkout page tests

### DIFF
--- a/test/checkout_test.js
+++ b/test/checkout_test.js
@@ -3,7 +3,8 @@ var supertest = require('supertest');
 var superagent = require('superagent');
 var agent = superagent.agent();
 
-var api = supertest('http://localhost:3000');
+var PORT = process.env.PORT || '3000';
+var api = supertest('http://localhost:' + PORT);
 var gateway = require('../lib/gateway');
 
 describe('Checkout index page', function(){


### PR DESCRIPTION
# Problem

If you change the PORT env variable, this is not respected in the tests.
# Solution

Change the tests to start against the app with the PORT env variable, defaulting to '3000' like the main app. 
