### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "0.12"
+before_script:
+  - "npm start &"
+  - sleep 3
+notifications:
+  email:
+    - "external-ci-notifications+braintree_express_example@getbraintree.com"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Braintree Express Example
+
+[![Build Status](https://travis-ci.org/braintree/braintree_express_example.svg?branch=master)](https://travis-ci.org/braintree/braintree_express_example)
 An example Braintree integration for Node in the Express framework.
 
 ## Setup Instructions

--- a/test/checkout_test.js
+++ b/test/checkout_test.js
@@ -87,7 +87,7 @@ describe('Checkouts show page', function () {
 
   it('displays a success page when transaction succeeded', function (done) {
     gateway.transaction.sale({
-      amount: '10.00',
+      amount: '11.00',
       paymentMethodNonce: 'fake-valid-nonce'
     }, function (err, result) {
       var transaction = result.transaction;


### PR DESCRIPTION
Adds a Travis CI integration to the express example. A minor adjustment was required to a test amount to avoid an unwanted gateway error. It may be better to implement a sequencing mechanism in another PR.