### PR TITLE
Update braintree.js URL to latest version

### DIFF
--- a/views/checkouts/new.jade
+++ b/views/checkouts/new.jade
@@ -19,7 +19,7 @@ block content
       button.button(type="submit")
         span Test Transaction
 
-  script(src="https://js.braintreegateway.com/v2/braintree.js")
+  script(src="https://js.braintreegateway.com/js/braintree-2.27.0.min.js")
   script.
     (function () {
       var checkout = new Demo({


### PR DESCRIPTION
Trying to use the different PayPal checkout button I was seriously confused why this didn't work:

    button: {
         type: 'checkout'
     }

After a few hours of debugging and trying to replicate it on JSBin for a bug report on braintree-web, it turns out the referenced https://js.braintreegateway.com/v2/braintree.js is not actually the latest v2 SDK version and doesn't support this PayPal checkout button.

Redirecting `https://js.braintreegateway.com/v2/braintree.js` to the latest version might be a better idea.

(FWIW, Stripe Checkout always uses the latest version.)