### PR TITLE
submit transactions for settlement by default

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -74,7 +74,10 @@ router.post('/checkouts', function (req, res) {
 
   gateway.transaction.sale({
     amount: amount,
-    paymentMethodNonce: nonce
+    paymentMethodNonce: nonce,
+    options: {
+      submitForSettlement: true
+    }
   }, function (err, result) {
     if (result.success || result.transaction) {
       res.redirect('checkouts/' + result.transaction.id);

--- a/test/checkout_test.js
+++ b/test/checkout_test.js
@@ -55,7 +55,10 @@ describe('Checkouts show page', function () {
   it('respond with 200', function (done) {
     gateway.transaction.sale({
       amount: '10.00',
-      paymentMethodNonce: 'fake-valid-nonce'
+      paymentMethodNonce: 'fake-valid-nonce',
+      options: {
+        submitForSettlement: true
+      }
     }, function (err, result) {
       var transaction = result.transaction;
 
@@ -66,7 +69,10 @@ describe('Checkouts show page', function () {
   it('displays the transaction\'s fields', function (done) {
     gateway.transaction.sale({
       amount: '10.00',
-      paymentMethodNonce: 'fake-valid-nonce'
+      paymentMethodNonce: 'fake-valid-nonce',
+      options: {
+        submitForSettlement: true
+      }
     }, function (err, result) {
       var transaction = result.transaction;
 
@@ -88,7 +94,10 @@ describe('Checkouts show page', function () {
   it('displays a success page when transaction succeeded', function (done) {
     gateway.transaction.sale({
       amount: '11.00',
-      paymentMethodNonce: 'fake-valid-nonce'
+      paymentMethodNonce: 'fake-valid-nonce',
+      options: {
+        submitForSettlement: true
+      }
     }, function (err, result) {
       var transaction = result.transaction;
 
@@ -102,7 +111,10 @@ describe('Checkouts show page', function () {
   it('displays a failure page when transaction failed', function (done) {
     gateway.transaction.sale({
       amount: '2000.00',
-      paymentMethodNonce: 'fake-valid-nonce'
+      paymentMethodNonce: 'fake-valid-nonce',
+      options: {
+        submitForSettlement: true
+      }
     }, function (err, result) {
       var transaction = result.transaction;
 


### PR DESCRIPTION
## Submit transactions for settlement by default

Currently, transactions are not submitted for settlement on the checkouts page. This would submit them automatically. For people using this repository to test out Braintree, this is useful as they don't have to manually submit each transaction they make in sandbox.