### PR TITLE
Bump SDK and Drop-in versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.9.1"
 before_script:
   - "npm start &"
   - sleep 3

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jade": "~1.11.0",
     "morgan": "~1.6.1",
     "serve-favicon": "~2.3.0",
-    "braintree": "^1.30.0",
+    "braintree": "^2.9.0",
     "dotenv": "~1.2.0",
     "connect-flash": "~0.1.1",
     "express-session": "~1.12.1"

--- a/views/checkouts/new.jade
+++ b/views/checkouts/new.jade
@@ -20,7 +20,7 @@ block content
       button.button(type="submit")
         span Test Transaction
 
-  script(src="https://js.braintreegateway.com/web/dropin/1.9.4/js/dropin.min.js")
+  script(src="https://js.braintreegateway.com/web/dropin/1.10.0/js/dropin.min.js")
   script.
     var form = document.querySelector('#payment-form');
     var token = '#{clientToken}';


### PR DESCRIPTION
Bumping Braintree Node SDK to 2.9.0, and Braintree Drop-in to 1.10.0

Also bumping Node version in Travis to support updated SDK.