### PR TITLE
Throw error when missing env variables

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -4,6 +4,11 @@ var braintree = require('braintree');
 var environment, gateway;
 
 require('dotenv').config();
+
+if (!process.env.BT_ENVIRONMENT || !process.env.BT_MERCHANT_ID || !process.env.BT_PUBLIC_KEY || !process.env.BT_PRIVATE_KEY) {
+  throw new Error('Cannot find necessary environmental variables. See https://github.com/braintree/braintree_express_example#setup-instructions for instructions');
+}
+
 environment = process.env.BT_ENVIRONMENT.charAt(0).toUpperCase() + process.env.BT_ENVIRONMENT.slice(1);
 
 gateway = braintree.connect({


### PR DESCRIPTION
A constant source of issues on these repos is forgetting to set the .env file. This throws an error and points to the instructions.