### PR TITLE
GHA - set env vars before integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ jobs:
 
       - run: npm ci
       - run: npm run test:unit
+      - name: Run integration tests
         env:
           BT_ENVIRONMENT: ${{ secrets.BT_ENVIRONMENT }}
           BT_MERCHANT_ID: ${{ secrets.BT_MERCHANT_ID }}
           BT_PUBLIC_KEY: ${{ secrets.BT_PUBLIC_KEY }}
           BT_PRIVATE_KEY: ${{ secrets.BT_PRIVATE_KEY }}
-      - run: npm start & sleep 3 && npm run test:integration
+        run: npm start & sleep 3 && npm run test:integration
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
 
       - run: npm ci
       - run: npm run test:unit
-      - run: npm start & sleep 3 && npm run test:integration
         env:
           BT_ENVIRONMENT: ${{ secrets.BT_ENVIRONMENT }}
           BT_MERCHANT_ID: ${{ secrets.BT_MERCHANT_ID }}
           BT_PUBLIC_KEY: ${{ secrets.BT_PUBLIC_KEY }}
           BT_PRIVATE_KEY: ${{ secrets.BT_PRIVATE_KEY }}
+      - run: npm start & sleep 3 && npm run test:integration
+        

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "body-parser": "^1.20.1",
-        "braintree": "^3.13.0",
+        "braintree": "^3.15.0",
         "connect-flash": "~0.1.1",
         "debug": "^4.3.4",
         "dotenv": "^16.0.3",
@@ -1687,13 +1687,13 @@
       }
     },
     "node_modules/braintree": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/braintree/-/braintree-3.13.0.tgz",
-      "integrity": "sha512-eWSpLxk+FV9rrREjR6n5d9OE7y4FujWFdIUK5Wpuip0Oug4Aj/9eXrUCMbDfVVF2Zozh4ciwL1Msaand28ViWQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/braintree/-/braintree-3.15.0.tgz",
+      "integrity": "sha512-J6Ps1nZvf3wiFitPyJYUNaThsY7ATDY7JyUo2kAppXK00ZvPRQ1N0XWp3XNPhNvdJGLRXjmamUvCatEKV9jb7g==",
       "dependencies": {
         "@braintree/wrap-promise": "2.1.0",
         "dateformat": "4.5.1",
-        "xml2js": "0.4.23"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">=10.0",
@@ -7293,9 +7293,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "body-parser": "^1.20.1",
-    "braintree": "^3.13.0",
+    "braintree": "^3.15.0",
     "connect-flash": "~0.1.1",
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
This is for fixing the GitHub Action failure for environment variables not set when running the integration tests in [Bump xml2js and braintree #69](https://github.com/braintree/braintree_express_example/pull/69)